### PR TITLE
Add Yelp For Yelp Reviews

### DIFF
--- a/_data/projects/eshs_programming_club/yelp_for_yelp_reviews.yml
+++ b/_data/projects/eshs_programming_club/yelp_for_yelp_reviews.yml
@@ -1,0 +1,8 @@
+name: Yelp For Yelp Reviews
+description: It's like Yelp, but for Yelp reviews.
+url: https://yelpforyelpreviews.com
+github_url: https://github.com/zachlatta/yelpforyelpreviews
+authors:
+  - Zach Latta
+  - Andrew Downing
+  - Chris Grant


### PR DESCRIPTION
Project details:
- Club: ESHS Programming Club
- Name: Yelp For Yelp Reviews
- Description: It's like Yelp, but for Yelp reviews.
- URL: https://yelpforyelpreviews.com
- GitHub: https://github.com/zachlatta/yelpforyelpreviews
- Authors:
  - Zach Latta
  - Andrew Downing
  - Chris Grant

:shipit:
