### PR TITLE
Update README to follow Markdown guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Shipped :shipit:
 
-
 This is a showcase of projects shipped by members of hackEDU clubs. Once you've
 shipped a project, please submit a [pull
 request](https://help.github.com/articles/using-pull-requests/) using the below
 instructions. The website is regenerated every three hours.
 
 ![](http://i.imgur.com/hv02NKH.gif)
+
 ## Install and Run
 
-Shipped runs on [Jekyll](http://jekyllrb.com/), so all you need to get up and running locally is  
+Shipped runs on [Jekyll](http://jekyllrb.com/), so all you need to get up and running locally is
+
 ```bash
 # Install Jekyll
 $ gem install jekyll


### PR DESCRIPTION
This change updates the README of this repository to follow our Markdown guidelines that's linked in https://github.com/hackedu/hackedu/blob/master/CONTRIBUTING.md#style-guides

@jonleung can you review/merge this when you have a chance?
