### PR TITLE
projects: club folders in _data removed

### DIFF
--- a/_data/projects/anonymous_warning.yml
+++ b/_data/projects/anonymous_warning.yml
@@ -2,6 +2,8 @@ name: Anonymous Warning
 description: This application allows you to Anonymously Message your friends.
 url: http://mahahahajan.github.io/AnonWarning/
 github_url: https://github.com/mahahahajan/AnonWarning
+clubs:
+  - Hack Camp
 authors:
   - Pulkit Mahajan
   - Gisela Kottmeier

--- a/_data/projects/build_your_own_lisp_-_gitbook.yml
+++ b/_data/projects/build_your_own_lisp_-_gitbook.yml
@@ -2,5 +2,7 @@ name: Build Your Own Lisp - Gitbook
 description: A port to gitbook of the ebook Build Your Own Lisp by Daniel Holden.
 url: http://landersbenjamin.gitbooks.io/buildyourownlisp/
 github_url: https://github.com/TheThirdOne/BuildYourOwnLispGitbook
+clubs:
+  - El Segundo High School
 authors:
   - Benjamin Landers

--- a/_data/projects/care_wall.yml
+++ b/_data/projects/care_wall.yml
@@ -2,6 +2,8 @@ name: Care Wall
 description: Because sometimes we forget what we really care about.
 url: http://careabout.herokuapp.com/
 github_url: https://github.com/jonleung/Care
+clubs:
+  - Hacker Paradise
 authors:
   - Jonathan Leung
   - Max Wofford

--- a/_data/projects/caster.link.yml
+++ b/_data/projects/caster.link.yml
@@ -2,6 +2,8 @@ name: caster.link
 description: Web-based live streaming for mobile devices. Compatible with Chrome and Firefox. Site/streaming may be down, we're trying to get our server fixed.
 url: http://caster.link
 github_url: https://github.com/jawerty/caster.link
+clubs:
+  - Cherry Hill High School East
 authors:
   - Bogdan Vitoc
   - Jared Wright

--- a/_data/projects/datawave.yml
+++ b/_data/projects/datawave.yml
@@ -2,6 +2,8 @@ name: DataWave
 description: Internet over FM radio waves. Plug the attachment into your android or computer audio jack and have an internet connection for miles
 url: http://challengepost.com/software/datawave
 github_url: https://github.com/datawaveteam
+clubs:
+  - Mundelein High School
 authors:
   - Raphael Rouvinov
   - Stefan Aleksic

--- a/_data/projects/distraction_free_facebook_messenger.yml
+++ b/_data/projects/distraction_free_facebook_messenger.yml
@@ -2,5 +2,7 @@ name: Distraction Free Facebook Messenger
 description: Eliminates all the distractions of Facebook Messenger.
 url: https://chrome.google.com/webstore/detail/distraction-free-facebook/ipkbhlfkopeokhpbhgmlonagpppedfej
 github_url: https://github.com/jonleung/distraction-free-facebook-messenger
+clubs:
+  - hackEDU
 authors:
   - Jonathan Leung

--- a/_data/projects/dogevertising.yml
+++ b/_data/projects/dogevertising.yml
@@ -2,6 +2,8 @@ name: Dogevertising
 description: A new way to profit from page views without advertising. TO THE MOON! Replace web ads with invisible dogecoin mining scripts!
 url: https://dogelabs.github.io/shibay/
 github_url: https://github.com/DogeLabs/shibay
+clubs:
+  - El Segundo High School
 authors:
   - Max Wofford
   - Luke St. Regis

--- a/_data/projects/eden.yml
+++ b/_data/projects/eden.yml
@@ -2,6 +2,8 @@ name: Eden
 description: We built a platform that lets you to break free from Apple's walled garden. With Eden, you can deploy a personal OS X instance on Amazon EC2, Linode, or any other cloud provider in minutes, and use it to securely relay iMessage to any platform -- including Android, Windows Phone, and the web.
 url: http://challengepost.com/software/eden
 github_url: https://github.com/zachlatta/eden
+clubs:
+  - hackEDU
 authors:
   - Zach Latta
   - Avi Romanoff

--- a/_data/projects/el_pinguino.yml
+++ b/_data/projects/el_pinguino.yml
@@ -2,6 +2,8 @@ name: El Pinguino
 description: El Pinguino lets you scrape Travelmob locations by country and convert to JSON.
 url: https://github.com/HackerParadise2014/el_pinguino
 github_url: https://github.com/HackerParadise2014/el_pinguino
+clubs:
+  - Hacker Paradise
 authors:
   - Max Wofford
   - Rob Cole

--- a/_data/projects/furfante.yml
+++ b/_data/projects/furfante.yml
@@ -1,5 +1,7 @@
 name: Furfante
 description: You fly around in a virtual city and destroy stuff. It's like a super hero game, but not.
 github_url: https://github.com/gemmabusoni/HackSC
+clubs:
+  - hackEDU
 authors:
   - Gemma Busoni

--- a/_data/projects/handi-hacked.yml
+++ b/_data/projects/handi-hacked.yml
@@ -2,6 +2,8 @@ name: Handi-Hacked
 description: Handi-hacked is a VR input device designed to make virtual reality easily accessible for all. Such a device allows the joys of VR to be simple and intuitive for all handicapped people, as the input device supports a plethora of wheelchairs (motorized or not). Furthermore, it is also a great tool for therapies, VR enthusiasts, or one who may have interest in life bound to a wheelchair.
 url: http://hackgeny.challengepost.com/submissions/32141-handi-hacked
 github_url: https://github.com/raphaelrk/CatDaddy
+clubs:
+  - Elizabeth High School
 authors:
   - Amy Sorto
   - Raphael Rouvinov

--- a/_data/projects/kenko.yml
+++ b/_data/projects/kenko.yml
@@ -2,6 +2,8 @@ name: Kenko
 description: Shazam for food. Top ten at PennApps XII, and winner of the Best Cloud-based Mobile Application (Sponsored by Goldman Sachs).
 url: http://devpost.com/software/kenko-dnovlh
 github_url: http://www.github.com/gmittal/shokuji
+clubs:
+  - Gunn High School
 authors:
   - Gautam Mittal
   - Kevin Frans

--- a/_data/projects/leap_music.yml
+++ b/_data/projects/leap_music.yml
@@ -1,6 +1,8 @@
 name: Leap Music
 description: A Chrome Extension that uses the leap motion to control pandora.
 github_url: https://github.com/austincarvey/LeapMusic
+clubs:
+  - HSMSE, Stuyvesant High School, Trinity Club
 authors:
   - Austin Carvey
   - Philip Steinman

--- a/_data/projects/leungmichael.com.yml
+++ b/_data/projects/leungmichael.com.yml
@@ -2,5 +2,7 @@ name: leungmichael.com
 description: Leungmichael.com is just a personal website I made from the skills I learned at hackEDU's Hack Camp. On this website, I will be posting current and already finished coding projects.
 url: http://leungmichael.com/
 github_url: https://github.com/MiLeung/MiLeung.github.io
+clubs:
+  - Hack Camp
 authors:
   - Michael Leung

--- a/_data/projects/myobserver.yml
+++ b/_data/projects/myobserver.yml
@@ -2,6 +2,8 @@ name: MyObserver
 description: MyObserver is an iOS app that allows users to interact with Google Street View using Google Cardboard. The user can also zoom in and out using a Myo device.
 url: http://challengepost.com/software/myobserver
 github_url: https://github.com/jackcook/myobserver
+clubs:
+  - Townsend Harris High School
 authors:
   - Jack Cook
   - Tim Hung

--- a/_data/projects/pearl_runner.yml
+++ b/_data/projects/pearl_runner.yml
@@ -2,6 +2,8 @@ name: Pearl Runner
 description: Too often, sexual education is dismissed as taboo in our culture. Through Pearl Runner, a young girl discovers the value of sexual health and safety by collecting condoms and avoiding the plague of STDs that are infecting her life. Inspired by stories of young girls overcoming sexual harassment, teenage pregnancy, and other consequences of poor sexual education, we strove to create a welcoming environment for users of all ages to learn and break down the walls of sexual taboo.
 url: http://challengepost.com/software/pearl-runner-hk22c
 github_url: https://github.com/sharon-lin/PearlHacks
+clubs:
+  - Elizabeth High School
 authors:
   - Amy Sorto
   - Karla Rodriguez

--- a/_data/projects/shibesales.yml
+++ b/_data/projects/shibesales.yml
@@ -2,5 +2,7 @@ name: ShibeSales
 description: Miss a sale on Steam? Buy it for cheap with Dogecoin! At ShibeSales you can purchase Steam games on sale, and recommend games for us to keep on our watchlist.
 url: http://shibesales.com/
 github_url: https://github.com/MaxWofford/Shibe-Sales
+clubs:
+  - hackEDU
 authors:
   - Max Wofford

--- a/_data/projects/ship_it.yml
+++ b/_data/projects/ship_it.yml
@@ -2,5 +2,7 @@ name: Ship It
 description: Utility website for generating pull requests to submit projects to https://shipped.hackedu.us.
 url: https://shipit.hackedu.us
 github_url: https://github.com/hackedu/shipit
+clubs:
+  - hackEDU
 authors:
   - Zach Latta

--- a/_data/projects/smart_sight.yml
+++ b/_data/projects/smart_sight.yml
@@ -1,6 +1,8 @@
 name: Smart Sight
 description: An augmented reality real-time app that can identify products and the companies that produce them. It then displays the stock price along with other financial data of the company right on the camera screen in addition to providing a way to order the product that you see.
 github_url: https://github.com/himat/SmartSight
+clubs:
+  - Middlesex County Academy
 authors:
   - Hima Tammineedi
   - Syed Raziq Mohideen

--- a/_data/projects/tweetvr.yml
+++ b/_data/projects/tweetvr.yml
@@ -2,6 +2,8 @@ name: tweetVR
 description: tweetVR augments tweets onto Google Maps Streetview for your Twitter viewing pleasure. Our targeted users are those who know there are infinite ways to view data. Users can view tweets, in virtual reality, in a radius of their current location or see what people are tweeting in a totally different hemisphere. Now what can be a better and faster way to discover what's trending around your current physical surroundings? :)
 url: http://challengepost.com/software/tweetvr
 github_url: https://github.com/gauss1181/MHacksV
+clubs:
+  - International Academy East
 authors:
   - Shriyash Jalukar
   - Megan Chen

--- a/_data/projects/ventib.yml
+++ b/_data/projects/ventib.yml
@@ -2,6 +2,8 @@ name: Ventib
 description: Ventib records all your speech, transcribes it, and sends it to a server for processing. Ventib's server then analyzes the data to provide statistics. Ventib also has a search function, which allows users to search through their past speech and obtain timestamped logs with location data.
 url: http://github.com/cydrobolt/ventib
 github_url: http://github.com/cydrobolt/ventib
+clubs:
+  - Radnor High School
 authors:
   - Chaoyi Zha
   - Fox Wilson

--- a/index.html
+++ b/index.html
@@ -12,15 +12,11 @@ layout: default
     each directory and file as an array. Hopefully there's a better way to do
     this.
     {% endcomment %}
-    {% for club in site.data.projects %}
-      {% for project_file in club %}
-        {% for projects in project_file %}
-          {% for project in projects %}
-            {% if project.name != null %}
-              {% include project_card.html project=project %}
-            {% endif %}
-          {% endfor %}
-        {% endfor %}
+    {% for project_file in site.data.projects %}
+      {% for project in project_file %}
+        {% if project.name != null %}
+          {% include project_card.html project=project %}
+        {% endif %}
       {% endfor %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
This displays .yml files from `_data/project/` instead of `_data/project/CLUBNAME/`, as well as moves all existing .yml files into `_data/project/`.

Goes along with https://github.com/hackedu/shipit/pull/45
